### PR TITLE
Fixes for 1.20 - replacing deprecated screen handling / drawing methods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,19 +3,19 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric & Minecraft
 # https://fabricmc.net/develop
-minecraft_version=1.19.4
-yarn_mappings=1.19.4+build.1
-loader_version=0.14.17
+minecraft_version=1.20
+yarn_mappings=1.20+build.1
+loader_version=0.14.21
 
 #Fabric api
-fabric_version=0.76.0+1.19.4
+fabric_version=0.83.0+1.20
 
 # Polymer
 # https://maven.nucleoid.xyz/eu/pb4/polymer-bundled
-polymer_version = 0.4.0+1.19.4
+polymer_version = 0.5.0-rc.3+1.20
 
 # Copper Hopper
-mod_version = 0.2.1+1.19.4-prerelease
+mod_version = 0.3.0+1.20.0
 maven_group = net.pcal
 archives_base_name = copperhopper
 

--- a/src/main/java/net/pcal/copperhopper/CohoInitializer.java
+++ b/src/main/java/net/pcal/copperhopper/CohoInitializer.java
@@ -2,13 +2,14 @@ package net.pcal.copperhopper;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.client.screenhandler.v1.ScreenRegistry;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
-import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.registry.Registries;
+import net.minecraft.resource.featuretoggle.FeatureFlags;
+import net.minecraft.screen.ScreenHandlerType;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,7 +34,7 @@ public class CohoInitializer implements ModInitializer, ClientModInitializer {
     @Override
     public void onInitializeClient() {
         new ExactlyOnceInitializer();
-        ScreenRegistry.register(CohoService.getScreenHandlerType(), CohoScreen::new);
+        HandledScreens.register(CohoService.getScreenHandlerType(), CohoScreen::new);
     }
 
 
@@ -71,7 +72,7 @@ public class CohoInitializer implements ModInitializer, ClientModInitializer {
                     FabricBlockEntityTypeBuilder.create(CopperHopperBlockEntity::new, cohoBlock).build(null));
             register(Registries.ITEM, COHO_ITEM_ID, cohoItem);
             register(Registries.BLOCK, COHO_BLOCK_ID, cohoBlock);
-            ScreenHandlerRegistry.registerSimple(COHO_SCREEN_ID, CohoScreenHandler::new);
+            register(Registries.SCREEN_HANDLER, COHO_SCREEN_ID, new ScreenHandlerType(CohoScreenHandler::new, FeatureFlags.VANILLA_FEATURES));
         }
     }
 }

--- a/src/main/java/net/pcal/copperhopper/CohoScreen.java
+++ b/src/main/java/net/pcal/copperhopper/CohoScreen.java
@@ -1,8 +1,7 @@
 package net.pcal.copperhopper;
 
-import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HopperScreen;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.screen.HopperScreenHandler;
 import net.minecraft.text.Text;
@@ -17,12 +16,9 @@ public class CohoScreen extends HopperScreen {
     }
 
     @Override
-    protected void drawBackground(MatrixStack matrices, float delta, int mouseX, int mouseY) {
-        //RenderSystem.setShader(GameRenderer::getPositionTexShader);
-        RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
-        RenderSystem.setShaderTexture(0, TEXTURE);
+    protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
         int i = (this.width - this.backgroundWidth) / 2;
         int j = (this.height - this.backgroundHeight) / 2;
-        drawTexture(matrices, i, j, 0, 0, this.backgroundWidth, this.backgroundHeight);
+        context.drawTexture(TEXTURE, i, j, 0, 0, this.backgroundWidth, this.backgroundHeight);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,9 +21,9 @@
     "copperhopper.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": ">=0.14.21",
     "fabric": "*",
-    "minecraft": "1.19.x",
+    "minecraft": "1.20.x",
     "java": ">=17"
   },
   "conflicts": {


### PR DESCRIPTION
I really like this mod and hope to be able to use it in 1.20 soon.

I made an attempt to update this mod for 1.20. After changing the dependencies and replacing the deprecated API calls, I was able to compile and run this mod. It seems to be working normally.

Hope this helps!