### PR TITLE
Fix textures and item name (1.21.4)

### DIFF
--- a/src/main/java/net/pcal/copperhopper/CohoInitializer.java
+++ b/src/main/java/net/pcal/copperhopper/CohoInitializer.java
@@ -103,7 +103,7 @@ public class CohoInitializer implements ModInitializer {
             //
             final CopperHopperBlock cohoBlock = new CopperHopperBlock(CopperHopperBlock.getDefaultSettings());
             final ResourceKey<Item> itemReourceKey = ResourceKey.create(Registries.ITEM, CopperHopperMod.COHO_ITEM_ID);
-            final CopperHopperItem cohoItem = new CopperHopperItem(cohoBlock, new Item.Properties().setId(itemReourceKey));
+            final CopperHopperItem cohoItem = new CopperHopperItem(cohoBlock, new Item.Properties().setId(itemReourceKey).useBlockDescriptionPrefix());
             ItemGroupEvents.modifyEntriesEvent(CreativeModeTabs.REDSTONE_BLOCKS).register(entries -> entries.addAfter(Items.HOPPER, cohoItem));
 
             cohoItem.registerBlocks(Item.BY_BLOCK, cohoItem); // wat

--- a/src/main/resources/assets/copperhopper/items/copper_hopper.json
+++ b/src/main/resources/assets/copperhopper/items/copper_hopper.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "copperhopper:item/copper_hopper"
+  }
+}

--- a/src/main/resources/assets/copperhopper/items/copper_hopper_minecart.json
+++ b/src/main/resources/assets/copperhopper/items/copper_hopper_minecart.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "copperhopper:item/copper_hopper_minecart"
+  }
+}


### PR DESCRIPTION
Title says it all. Added the needed item definition files and made the copper hopper item use the block name.